### PR TITLE
Improve memory usage during scraping

### DIFF
--- a/lib/nerves_metal_detector/vendors/adafruit_us.ex
+++ b/lib/nerves_metal_detector/vendors/adafruit_us.ex
@@ -24,8 +24,22 @@ defimpl NervesMetalDetector.Inventory.ProductAvailability.Fetcher,
   alias NervesMetalDetector.Vendors.AdafruitUs
 
   def fetch_availability(%AdafruitUs.ProductUpdate{url: url, sku: sku}) do
+    options = [
+      follow_redirect: true,
+      ssl: [
+        {:versions, :ssl.versions()[:supported]},
+        {:verify, :verify_peer},
+        {:cacertfile, :certifi.cacertfile()},
+        {:verify_fun, &:ssl_verify_hostname.verify_fun/3},
+        {:customize_hostname_check,
+         [
+           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+         ]}
+      ]
+    ]
+
     with {:load_body, {:ok, %{body: body}}} when body not in [nil, ""] <-
-           {:load_body, HTTPoison.get(url, [], follow_redirect: true)},
+           {:load_body, HTTPoison.get(url, [], options)},
          {:parse_document, parsed} when parsed not in [nil, []] <-
            {:parse_document, Floki.parse_document!(body)},
          {:parse_json_info, json_info} when json_info not in [%{}] <-

--- a/lib/nerves_metal_detector/vendors/pimoroni_uk.ex
+++ b/lib/nerves_metal_detector/vendors/pimoroni_uk.ex
@@ -24,8 +24,22 @@ defimpl NervesMetalDetector.Inventory.ProductAvailability.Fetcher,
   alias NervesMetalDetector.Vendors.PimoroniUk
 
   def fetch_availability(%PimoroniUk.ProductUpdate{url: url, sku: sku}) do
+    options = [
+      follow_redirect: true,
+      ssl: [
+        {:versions, :ssl.versions()[:supported]},
+        {:verify, :verify_peer},
+        {:cacertfile, :certifi.cacertfile()},
+        {:verify_fun, &:ssl_verify_hostname.verify_fun/3},
+        {:customize_hostname_check,
+         [
+           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+         ]}
+      ]
+    ]
+
     with {:load_body, {:ok, %{body: body}}} when body not in [nil, ""] <-
-           {:load_body, HTTPoison.get(url, [], follow_redirect: true)},
+           {:load_body, HTTPoison.get(url, [], options)},
          {:parse_document, parsed} when parsed not in [nil, []] <-
            {:parse_document, Floki.parse_document!(body)},
          {:parse_json_info, json_info} when json_info not in [%{}] <-


### PR DESCRIPTION
According to the following link, simply passing `{:cacertfile, :certifi.cacertfile()}` to the ssl options for `HTTPoison` will reduce the memory usage because then the cert data is stored in an ETS table instead of being passed to every SSL handling process.
http://erlang.org/pipermail/erlang-questions/2019-June/098063.html

The following article mentions that the full list of ssl options needs to be given:
https://nts.strzibny.name/hackney-ssl-configuration/

It makes the code a bit messy, so we might put these options in a dedicated module at a later time. Or we abstract the HTTP request lib entirely.